### PR TITLE
SDL App, runs on Linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/bbredesen/go-vk-samples
 go 1.19
 
 require (
-	github.com/bbredesen/go-vk v1.2.203-0.2.0
+	github.com/bbredesen/go-vk v1.3.290-0.3.3
 	github.com/bbredesen/vkm v0.2.2
 	github.com/udhos/gwob v0.0.0-20200524213453-619810f75817
-	golang.org/x/sys v0.6.0
+	github.com/veandco/go-sdl2 v0.4.40
+	golang.org/x/sys v0.37.0
 )
 
 require github.com/bbredesen/gltf v0.0.0-20230304155607-fc029d20508e

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,17 @@ github.com/bbredesen/gltf v0.0.0-20230304155607-fc029d20508e h1:ofmFTAIEaznp2VW8
 github.com/bbredesen/gltf v0.0.0-20230304155607-fc029d20508e/go.mod h1:aBVPYcZqshbMgvoaO7xsqR10PsVQD3+jv3+k4AHKcOk=
 github.com/bbredesen/go-vk v1.2.203-0.2.0 h1:A+yKH9CRTDkEGYMXoop1WbAm7zJ+nqggwGabUQVIM/s=
 github.com/bbredesen/go-vk v1.2.203-0.2.0/go.mod h1:/EeS73bQon2oAIADH//1ceElCl+YxodjpfN4u12JcUs=
+github.com/bbredesen/go-vk v1.3.290-0.3.3 h1:p3PLUXaTLAMfjGmFINWG+WkD7gDumOhDr7Sg1IPnAZg=
+github.com/bbredesen/go-vk v1.3.290-0.3.3/go.mod h1:6A3vfmSTrcgXEnBSP2JOw4jR3Wy/ZnGeIf0LPdQE7As=
 github.com/bbredesen/vkm v0.2.2 h1:TGhJruX9z0uAE3AONRIbYacimesUmFccnw68Q/GjYnw=
 github.com/bbredesen/vkm v0.2.2/go.mod h1:MjhNAnfvgNbTyBhXOmJXvExlWa216q5BqQJFQT8W9Vg=
 github.com/chewxy/math32 v1.10.1 h1:LFpeY0SLJXeaiej/eIp2L40VYfscTvKh/FSEZ68uMkU=
 github.com/chewxy/math32 v1.10.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/udhos/gwob v0.0.0-20200524213453-619810f75817 h1:4M105Yb9NHJ/sI3xAS3WbXt4d09q940504X5zE5JM7s=
 github.com/udhos/gwob v0.0.0-20200524213453-619810f75817/go.mod h1:kOhibXY50yGPKNcoFg+KDoC4hGzyJ6YX0wfKHhThntk=
+github.com/veandco/go-sdl2 v0.4.40 h1:fZv6wC3zz1Xt167P09gazawnpa0KY5LM7JAvKpX9d/U=
+github.com/veandco/go-sdl2 v0.4.40/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/shared/app_sdl.go
+++ b/shared/app_sdl.go
@@ -1,0 +1,174 @@
+package shared
+
+/*
+#include <stdlib.h>
+#include "vulkan/vulkan.h"
+*/
+import "C"
+import (
+	"github.com/bbredesen/go-vk"
+	"github.com/veandco/go-sdl2/sdl"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+func NewApp(windowTitle string) (App, error) {
+	app := &sdlApp{
+		newSharedApp(windowTitle),
+		nil,
+	}
+
+	if err := sdl.Init(sdl.INIT_VIDEO); err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}
+
+type sdlApp struct {
+	sharedApp
+
+	window *sdl.Window
+}
+
+// Run() must be called from the main thread and it is blocking until the window
+// is closed.  You should start a goroutine to read the message channel provided
+// by this App. That channel will be closed after the window is closed.
+func (app *sdlApp) Run() error {
+	runtime.LockOSThread()
+
+	if app.reqWidth < 0 || app.reqHeight < 0 {
+		app.reqWidth = 640
+		app.reqHeight = 480
+	}
+
+	var err error
+	app.window, err = sdl.CreateWindow(app.title, sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
+		int32(app.reqWidth), int32(app.reqHeight), sdl.WINDOW_SHOWN|sdl.WINDOW_VULKAN|sdl.WINDOW_RESIZABLE)
+	if err != nil {
+		return err
+	}
+
+	globalChannel <- EventMessage{Type: ET_Sys_Created}
+
+	// this event polling loop is better be run in the main thread once per each app.drawFrame()
+	for event := sdl.PollEvent(); true; event = sdl.PollEvent() {
+		switch e := event.(type) {
+		case *sdl.QuitEvent:
+			globalChannel <- EventMessage{Type: ET_Sys_Closed}
+			break
+		case *sdl.WindowEvent:
+			switch e.Event {
+			case sdl.WINDOWEVENT_MINIMIZED:
+				globalChannel <- EventMessage{Type: ET_Sys_Minimize}
+			case sdl.WINDOWEVENT_RESTORED:
+				globalChannel <- EventMessage{Type: ET_Sys_UnMinimize}
+			case sdl.WINDOWEVENT_RESIZED:
+				// resize seems atomic to the sdl lib, not sure which event type to send
+				globalChannel <- EventMessage{Type: ET_Sys_ResizeStart}
+				globalChannel <- EventMessage{Type: ET_Sys_ResizeProgress}
+				globalChannel <- EventMessage{Type: ET_Sys_ResizeComplete}
+			}
+		case *sdl.KeyboardEvent:
+			sendKeyEvent(e)
+		case *sdl.MouseWheelEvent:
+			sendMouseWheelEvent(e)
+		case *sdl.MouseMotionEvent:
+			sendMouseMotion(e)
+		case *sdl.MouseButtonEvent:
+			sendMouseButton(e)
+		}
+		if event == nil {
+			time.Sleep(time.Millisecond * 100) // a bit less active waiting
+		}
+	}
+
+	return nil
+}
+
+var eventTypeBySdlState = map[uint8]EventType{
+	sdl.PRESSED:  ET_Key_Down,
+	sdl.RELEASED: ET_Key_Up,
+}
+
+func sendKeyEvent(e *sdl.KeyboardEvent) {
+	globalChannel <- EventMessage{
+		Type: eventTypeBySdlState[e.State],
+		KeyEvent: &KeyEvent{
+			KeyCode: e.Keysym.Mod,
+			// TODO modifiers?
+		},
+	}
+}
+
+var currentlyPressedMouse MouseBtnBitFlags
+
+func sendMouseWheelEvent(e *sdl.MouseWheelEvent) {
+	event := basicMouseEvent()
+	event.Type = ET_Mouse_Scroll
+	// the amount scrolled is e.PreciseY
+	globalChannel <- event
+}
+
+func sendMouseMotion(e *sdl.MouseMotionEvent) {
+	event := basicMouseEvent()
+	if currentlyPressedMouse&MouseBtnLeft > 0 {
+		event.Type = ET_Mouse_Drag
+	} else {
+		event.Type = ET_Mouse_Move
+	}
+	globalChannel <- event
+}
+
+var buttonFlagBySdlEnum = map[uint8]MouseBtnBitFlags{
+	sdl.BUTTON_LEFT:   MouseBtnLeft,
+	sdl.BUTTON_RIGHT:  MouseBtnRight,
+	sdl.BUTTON_MIDDLE: MouseBtnMiddle,
+}
+
+var buttonEventBySdlEnum = map[uint8]EventType{
+	sdl.PRESSED:  ET_Mouse_ButtonDown,
+	sdl.RELEASED: ET_Mouse_ButtonUp,
+}
+
+func sendMouseButton(e *sdl.MouseButtonEvent) {
+	buttonFlag := buttonFlagBySdlEnum[e.Button]
+	if e.State == sdl.PRESSED {
+		currentlyPressedMouse |= buttonFlag
+	} else {
+		currentlyPressedMouse &^= buttonFlag
+	}
+
+	event := basicMouseEvent()
+	event.Type = buttonEventBySdlEnum[e.Button]
+	event.MouseEvent.TriggerButtonMask = buttonFlag
+	globalChannel <- event
+}
+
+func basicMouseEvent() EventMessage {
+	x, y, _ := sdl.GetMouseState()
+	return EventMessage{
+		MouseEvent: &MouseEvent{
+			LocationX:   uint16(x),
+			LocationY:   uint16(y),
+			ButtonsMask: currentlyPressedMouse,
+		},
+	}
+}
+
+func (app *sdlApp) GetRequiredInstanceExtensions() []string {
+	return append(app.window.VulkanGetInstanceExtensions(), vk.KHR_SURFACE_EXTENSION_NAME)
+}
+
+func (app *sdlApp) DelegateCreateSurface(instance vk.Instance) (vk.SurfaceKHR, error) {
+	pointer, err := app.window.VulkanCreateSurface((*C.VkInstance)(unsafe.Pointer(instance)))
+	if err != nil {
+		return 0, err
+	}
+	s := (*vk.SurfaceKHR)(pointer)
+	return *s, nil
+}
+
+func (app *sdlApp) OkToClose(handle uintptr) {
+}


### PR DESCRIPTION
Following [example](https://github.com/vkngwrapper/integrations/blob/sdl2/v2.1.0/sdl2/extension.go) from [CannibalVox](https://github.com/CannibalVox) I've set up an SDL app using [go-sdl2](https://github.com/veandco/go-sdl2) library.
Events polling is not implemented in the most efficient lag-free way, but I guess it's ok as an example.

The patch has been tested on Arch Linux, but SDL is compatible with Windows and Mac as well.
SDL might be the platform-independent way to create window and surface, however non-Linux testing is required.